### PR TITLE
fix error downloading cartidges by using https

### DIFF
--- a/src/main/java/menion/android/whereyougo/network/DownloadCartridgeTask.java
+++ b/src/main/java/menion/android/whereyougo/network/DownloadCartridgeTask.java
@@ -41,7 +41,7 @@ public class DownloadCartridgeTask extends
         AsyncTask<String, DownloadCartridgeTask.Progress, Boolean> {
     private static final String TAG = "DownloadCartridgeTask";
     private static final String LOGIN = "https://www.wherigo.com/login/default.aspx";
-    private static final String DOWNLOAD = "http://www.wherigo.com/cartridge/download.aspx";
+    private static final String DOWNLOAD = "https://www.wherigo.com/cartridge/download.aspx";
 
     private final String username;
     private final String password;


### PR DESCRIPTION
wherigo.com switched from http to https for all urls about 2 weeks ago. Since then downloads from within WhereYouGo are failing with just "error".